### PR TITLE
feat: 会员前台支持用户自定义主题色

### DIFF
--- a/packages/web/src/member/components/ThemeColorPicker.tsx
+++ b/packages/web/src/member/components/ThemeColorPicker.tsx
@@ -1,0 +1,56 @@
+import { Check } from 'lucide-react';
+import { useMemberTheme, THEME_PRESETS } from '../hooks/useMemberTheme';
+
+export function ThemeColorPicker() {
+  const { themeColor, setThemeColor } = useMemberTheme();
+
+  return (
+    <div>
+      <div style={{ fontSize: 13, color: 'var(--m-text-secondary)', marginBottom: 16 }}>
+        选择你喜欢的主题色，偏好会保存在本设备
+      </div>
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+        {THEME_PRESETS.map((preset) => {
+          const selected = themeColor === preset.color;
+          return (
+            <div key={preset.name} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
+              <button
+                title={preset.label}
+                onClick={() => setThemeColor(preset.color)}
+                aria-label={preset.label}
+                aria-pressed={selected}
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: '50%',
+                  background: preset.color,
+                  border: selected ? '3px solid #fff' : '3px solid transparent',
+                  boxShadow: selected ? `0 0 0 2px ${preset.color}` : '0 1px 4px rgba(0,0,0,0.15)',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 0,
+                  transition: 'box-shadow 0.15s, transform 0.15s',
+                  flexShrink: 0,
+                }}
+              >
+                {selected && <Check size={16} color="#fff" strokeWidth={3} />}
+              </button>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: selected ? preset.color : 'var(--m-text-tertiary)',
+                  fontWeight: selected ? 600 : 400,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {preset.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/member/components/ThemeColorPicker.tsx
+++ b/packages/web/src/member/components/ThemeColorPicker.tsx
@@ -1,8 +1,8 @@
 import { Check } from 'lucide-react';
-import { useMemberTheme, THEME_PRESETS } from '../hooks/useMemberTheme';
+import { useMemberTheme } from '../hooks/useMemberTheme';
 
 export function ThemeColorPicker() {
-  const { themeColor, setThemeColor } = useMemberTheme();
+  const { themeColor, setThemeColor, presets } = useMemberTheme();
 
   return (
     <div>
@@ -10,11 +10,12 @@ export function ThemeColorPicker() {
         选择你喜欢的主题色，偏好会保存在本设备
       </div>
       <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end' }}>
-        {THEME_PRESETS.map((preset) => {
+        {presets.map((preset) => {
           const selected = themeColor === preset.color;
           return (
             <div key={preset.name} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
               <button
+                type="button"
                 title={preset.label}
                 onClick={() => setThemeColor(preset.color)}
                 aria-label={preset.label}

--- a/packages/web/src/member/hooks/useMemberTheme.ts
+++ b/packages/web/src/member/hooks/useMemberTheme.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from 'react';
+
+const THEME_COLOR_KEY = 'zenith_member_theme_color';
+export const DEFAULT_THEME_COLOR = '#07c160';
+
+export interface ThemePreset {
+  name: string;
+  color: string;
+  label: string;
+}
+
+export const THEME_PRESETS: ThemePreset[] = [
+  { name: 'green', color: '#07c160', label: '微信绿' },
+  { name: 'blue', color: '#1677ff', label: '天空蓝' },
+  { name: 'purple', color: '#722ed1', label: '优雅紫' },
+  { name: 'orange', color: '#fa8c16', label: '活力橙' },
+  { name: 'red', color: '#f5222d', label: '中国红' },
+  { name: 'teal', color: '#13c2c2', label: '青碧色' },
+  { name: 'pink', color: '#eb2f96', label: '粉玫瑰' },
+];
+
+/** 在 React 渲染前调用一次，避免主题闪烁 */
+export function initMemberTheme() {
+  const color = localStorage.getItem(THEME_COLOR_KEY) ?? DEFAULT_THEME_COLOR;
+  document.documentElement.style.setProperty('--m-primary', color);
+}
+
+export function useMemberTheme() {
+  const [themeColor, setThemeColorState] = useState<string>(
+    () => localStorage.getItem(THEME_COLOR_KEY) ?? DEFAULT_THEME_COLOR,
+  );
+
+  const setThemeColor = useCallback((color: string) => {
+    localStorage.setItem(THEME_COLOR_KEY, color);
+    document.documentElement.style.setProperty('--m-primary', color);
+    setThemeColorState(color);
+  }, []);
+
+  return { themeColor, setThemeColor, presets: THEME_PRESETS };
+}

--- a/packages/web/src/member/hooks/useMemberTheme.ts
+++ b/packages/web/src/member/hooks/useMemberTheme.ts
@@ -19,20 +19,41 @@ export const THEME_PRESETS: ThemePreset[] = [
   { name: 'pink', color: '#eb2f96', label: '粉玫瑰' },
 ];
 
+function safeGetColor(): string {
+  try {
+    return (typeof window !== 'undefined' && localStorage.getItem(THEME_COLOR_KEY)) || DEFAULT_THEME_COLOR;
+  } catch {
+    return DEFAULT_THEME_COLOR;
+  }
+}
+
+function safeSaveColor(color: string): void {
+  try {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(THEME_COLOR_KEY, color);
+    }
+  } catch {
+    // ignore — private mode or storage quota exceeded
+  }
+}
+
+function applyColor(color: string): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.style.setProperty('--m-primary', color);
+  }
+}
+
 /** 在 React 渲染前调用一次，避免主题闪烁 */
 export function initMemberTheme() {
-  const color = localStorage.getItem(THEME_COLOR_KEY) ?? DEFAULT_THEME_COLOR;
-  document.documentElement.style.setProperty('--m-primary', color);
+  applyColor(safeGetColor());
 }
 
 export function useMemberTheme() {
-  const [themeColor, setThemeColorState] = useState<string>(
-    () => localStorage.getItem(THEME_COLOR_KEY) ?? DEFAULT_THEME_COLOR,
-  );
+  const [themeColor, setThemeColorState] = useState<string>(safeGetColor);
 
   const setThemeColor = useCallback((color: string) => {
-    localStorage.setItem(THEME_COLOR_KEY, color);
-    document.documentElement.style.setProperty('--m-primary', color);
+    safeSaveColor(color);
+    applyColor(color);
     setThemeColorState(color);
   }, []);
 

--- a/packages/web/src/member/layouts/MemberLayout.tsx
+++ b/packages/web/src/member/layouts/MemberLayout.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { Outlet, useLocation, useNavigate, NavLink } from 'react-router-dom';
 import { Nav, Avatar, Modal } from '@douyinfe/semi-ui';
-import { Crown, House, Coins, Wallet, Ticket, UserCog, Lock, LogOut, ArrowLeft, History, CalendarCheck } from 'lucide-react';
+import { Crown, House, Coins, Wallet, Ticket, UserCog, Lock, LogOut, ArrowLeft, History, CalendarCheck, Settings } from 'lucide-react';
 import { useMemberAuth } from '../hooks/useMemberAuth';
 
 const NAV_ITEMS = [
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { itemKey: '/coupons', text: '我的卡券', icon: <Ticket size={15} /> },
   { itemKey: '/checkin', text: '每日签到', icon: <CalendarCheck size={15} /> },
   { itemKey: '/level', text: '等级权益', icon: <Crown size={15} /> },
+  { itemKey: '/profile', text: '个人设置', icon: <Settings size={15} /> },
   { itemKey: '/profile/edit', text: '编辑资料', icon: <UserCog size={15} /> },
   { itemKey: '/profile/password', text: '修改密码', icon: <Lock size={15} /> },
   { itemKey: '/login-history', text: '登录历史', icon: <History size={15} /> },

--- a/packages/web/src/member/main-member.tsx
+++ b/packages/web/src/member/main-member.tsx
@@ -5,6 +5,10 @@ import MemberApp from './App-member';
 import '../styles/global.css';
 import './styles/member.css';
 import { enableMocking } from '../mocks';
+import { initMemberTheme } from './hooks/useMemberTheme';
+
+// 提前应用主题色，避免页面闪烁
+initMemberTheme();
 
 async function bootstrap() {
   await enableMocking();

--- a/packages/web/src/member/pages/checkin/CheckinPage.tsx
+++ b/packages/web/src/member/pages/checkin/CheckinPage.tsx
@@ -113,7 +113,7 @@ export default function CheckinPage() {
   return (
     <MemberPage title="每日签到">
       <div style={{
-        background: 'linear-gradient(135deg, #07c160 0%, #19be6b 100%)',
+        background: 'linear-gradient(135deg, var(--m-primary-dark) 0%, var(--m-primary) 100%)',
         borderRadius: 16,
         color: '#fff',
         padding: 24,
@@ -140,7 +140,7 @@ export default function CheckinPage() {
               loading={loading}
               disabled={status?.checkedToday}
               onClick={handleCheckin}
-              style={{ background: '#fff', color: '#07c160', borderColor: '#fff' }}
+              style={{ background: '#fff', color: 'var(--m-primary)', borderColor: '#fff' }}
             >
               {status?.checkedToday ? '今日已签到' : '立即签到'}
             </Button>
@@ -187,7 +187,7 @@ export default function CheckinPage() {
                   width: 8,
                   height: 8,
                   borderRadius: '50%',
-                  background: '#07c160',
+                  background: 'var(--m-primary)',
                 }}
                 />
               );

--- a/packages/web/src/member/pages/profile/ProfilePage.tsx
+++ b/packages/web/src/member/pages/profile/ProfilePage.tsx
@@ -1,8 +1,9 @@
 import { useNavigate, Navigate } from 'react-router-dom';
 import { Avatar, Button, Modal } from '@douyinfe/semi-ui';
-import { Crown, LogOut } from 'lucide-react';
+import { Crown, LogOut, Palette } from 'lucide-react';
 import { useMemberAuth } from '../../hooks/useMemberAuth';
 import { MemberPage } from '../../components/MemberPage';
+import { ThemeColorPicker } from '../../components/ThemeColorPicker';
 
 export default function ProfilePage() {
   const navigate = useNavigate();
@@ -52,6 +53,23 @@ export default function ProfilePage() {
             {member.levelName}
           </span>
         )}
+      </div>
+
+      <div
+        style={{
+          background: '#fff',
+          borderRadius: 12,
+          border: '1px solid var(--m-border)',
+          padding: '20px 24px',
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 15, fontWeight: 600, marginBottom: 16 }}>
+          <Palette size={16} color="var(--m-primary)" />
+          个性化设置
+        </div>
+        <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 10, color: 'var(--m-text)' }}>主题颜色</div>
+        <ThemeColorPicker />
       </div>
 
       <Button

--- a/packages/web/src/member/styles/member.css
+++ b/packages/web/src/member/styles/member.css
@@ -1,12 +1,12 @@
 /* ============================================================
    会员前台（C 端）PC 端样式
-   主题色：绿色 #07c160；左侧边栏（Semi Nav）+ 内容区布局
+   主题色：由 --m-primary CSS 变量控制（默认 #07c160）；左侧边栏（Semi Nav）+ 内容区布局
    ============================================================ */
 
 :root {
   --m-primary: #07c160;
-  --m-primary-dark: #06ad56;
-  --m-primary-light: #e8f9f0;
+  --m-primary-dark: color-mix(in srgb, var(--m-primary) 88%, black);
+  --m-primary-light: color-mix(in srgb, var(--m-primary) 10%, white);
   --m-warning: #ff9f0a;
   --m-danger: #fa5151;
   --m-text: #1a1a1a;
@@ -206,7 +206,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #f0fdf4 0%, #e8f9f0 40%, #f5f6f8 100%);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--m-primary) 5%, white) 0%, var(--m-primary-light) 40%, var(--m-bg) 100%);
   padding: 24px;
 }
 
@@ -642,7 +642,7 @@ body {
 
 /* Hero 区域 */
 .mc-hero {
-  background: linear-gradient(135deg, #07c160 0%, #0aab54 60%, #08974d 100%);
+  background: linear-gradient(135deg, var(--m-primary) 0%, var(--m-primary-dark) 60%, color-mix(in srgb, var(--m-primary) 75%, black) 100%);
   padding: 100px 40px;
   display: flex;
   align-items: center;
@@ -732,7 +732,7 @@ body {
 }
 
 .mc-feature-card:hover {
-  box-shadow: 0 8px 24px rgba(7, 193, 96, 0.12);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--m-primary) 15%, transparent);
   transform: translateY(-3px);
 }
 
@@ -765,7 +765,7 @@ body {
 /* CTA 区域 */
 .mc-cta-section {
   padding: 80px 40px;
-  background: linear-gradient(135deg, #07c160 0%, #0aab54 100%);
+  background: linear-gradient(135deg, var(--m-primary) 0%, var(--m-primary-dark) 100%);
   text-align: center;
 }
 


### PR DESCRIPTION
## Why

The member frontend previously used a hardcoded green theme (`#07c160`). There was no way for users to personalize the interface color, and the color was scattered as raw hex values across CSS and TSX files, making it fragile to change.

## What changed

Introduced a lightweight client-side theme color system backed by a single CSS variable (`--m-primary`) and `localStorage`.

**Key design decisions:**

- Only `--m-primary` is stored and set dynamically. Derived colors (`--m-primary-dark`, `--m-primary-light`) are computed automatically via CSS `color-mix()`, so the entire palette updates from a single variable change -- no JS math needed.
- `initMemberTheme()` is called synchronously in `main-member.tsx` before React renders, preventing a flash of the default color on page load.
- The `useMemberTheme` hook is simple state + `localStorage` + `style.setProperty`; no context or global store needed since CSS variables propagate to all elements automatically.

**7 preset colors available:**

| Color | Hex |
|-------|-----|
| 微信绿 (default) | `#07c160` |
| 天空蓝 | `#1677ff` |
| 优雅紫 | `#722ed1` |
| 活力橙 | `#fa8c16` |
| 中国红 | `#f5222d` |
| 青碧色 | `#13c2c2` |
| 粉玫瑰 | `#eb2f96` |

**Entry point:** the "个性化设置" card added to the profile page (`/profile`), showing color swatches with checkmark + label.

## Files changed

- `hooks/useMemberTheme.ts` -- new hook + `initMemberTheme()` + preset definitions
- `components/ThemeColorPicker.tsx` -- new swatch picker component
- `main-member.tsx` -- call `initMemberTheme()` before bootstrap
- `pages/profile/ProfilePage.tsx` -- add theme picker card
- `styles/member.css` -- replace hardcoded `#07c160` gradient stops and `--m-primary-dark/light` with `color-mix()` derived values
- `pages/checkin/CheckinPage.tsx` -- replace inline hardcoded `#07c160` with CSS variable references