### PR TITLE
feat(member): 会员列表昵称列展示头像，移除超链接样式

### DIFF
--- a/packages/web/src/pages/member/MembersPage.tsx
+++ b/packages/web/src/pages/member/MembersPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, Input, Select, Space, Modal, Form, Toast, Tag, Spin, Row, Col, Dropdown, Typography, SplitButtonGroup } from '@douyinfe/semi-ui';
+import { Button, Input, Select, Space, Modal, Form, Toast, Tag, Spin, Row, Col, Dropdown, SplitButtonGroup } from '@douyinfe/semi-ui';
 import type { FormApi } from '@douyinfe/semi-ui/lib/es/form/interface';
 import type { ColumnProps } from '@douyinfe/semi-ui/lib/es/table';
 import { Search, Plus, RotateCcw, Download, KeyRound, MoreHorizontal, ChevronDown } from 'lucide-react';
@@ -8,6 +8,7 @@ import { MEMBER_STATUS_LABELS } from '@zenith/shared';
 import { request } from '@/utils/request';
 import { usePermission } from '@/hooks/usePermission';
 import { usePagination } from '@/hooks/usePagination';
+import { UserAvatar } from '@/components/UserAvatar';
 import { SearchToolbar } from '@/components/SearchToolbar';
 import { AppModal } from '@/components/AppModal';
 import ConfigurableTable from '@/components/ConfigurableTable';
@@ -143,14 +144,15 @@ export default function MembersPage() {
 
   const columns: ColumnProps<Member>[] = [
     {
-      title: '昵称', dataIndex: 'nickname', width: 140,
+      title: '昵称', dataIndex: 'nickname', width: 180,
       render: (v: string, record: Member) => (
-        <Typography.Text
-          link onClick={() => setDetailMemberId(record.id)}
-          style={{ cursor: 'pointer' }}
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', minWidth: 0 }}
+          onClick={() => setDetailMemberId(record.id)}
         >
-          {v}
-        </Typography.Text>
+          <UserAvatar name={v || record.username || '?'} avatar={record.avatar} semiSize="extra-small" size={24} />
+          <span className="table-cell-ellipsis" title={v}>{v}</span>
+        </div>
       ),
     },
     { title: '用户名', dataIndex: 'username', width: 120, render: (v: string | null) => v || '-' },


### PR DESCRIPTION
## 问题

后台会员列表的昵称列使用了 `Typography.Text link` 来实现点击跳详情的交互，导致昵称文字被渲染为蓝色超链接样式，在视觉上与其他列（如用户名、手机号）风格不一致，且没有头像展示，与系统管理的用户管理页面体验存在差距。

## 改动

- 将昵称列的 `Typography.Text link` 替换为 `div + UserAvatar + span` 布局，与用户管理页保持一致
- 复用现有 `UserAvatar` 组件：有头像 URL 时显示图片，无头像时自动显示昵称首字母 + 哈希背景色
- 移除蓝色超链接样式，改用 `cursor: pointer` 保留点击打开详情抽屉的交互
- 昵称列宽度从 140 调整为 180，以容纳头像和文字
- 移除不再使用的 `Typography` 导入