### PR TITLE
fix(db): make data migrations safe on a fresh (unseeded) database

### DIFF
--- a/packages/server/drizzle/0084_scheduled_announcement.sql
+++ b/packages/server/drizzle/0084_scheduled_announcement.sql
@@ -1,6 +1,8 @@
 -- 添加「定时发布」字典项到公告发布状态字典 (dictId: 7)
+-- 仅当目标字典 (id=7) 已存在时插入，避免在全新数据库（迁移先于种子执行）上触发外键约束
 INSERT INTO "dict_items" ("dict_id", "label", "value", "color", "sort", "status", "created_at", "updated_at")
-VALUES (7, '定时发布', 'scheduled', 'blue', 4, 'enabled', NOW(), NOW())
+SELECT 7, '定时发布', 'scheduled', 'blue', 4, 'enabled', NOW(), NOW()
+WHERE EXISTS (SELECT 1 FROM "dicts" WHERE "id" = 7)
 ON CONFLICT DO NOTHING;
 
 -- 添加「定时公告自动发布」cron job

--- a/packages/server/drizzle/0177_romantic_leech.sql
+++ b/packages/server/drizzle/0177_romantic_leech.sql
@@ -28,7 +28,10 @@ VALUES
 ON CONFLICT ("id") DO NOTHING;
 --> statement-breakpoint
 INSERT INTO "role_menus" ("role_id", "menu_id")
-SELECT 1, "id" FROM "menus" WHERE "id" IN (535, 536)
+SELECT r."id", m."id"
+FROM "roles" r
+JOIN "menus" m ON m."id" IN (535, 536)
+WHERE r."code" = 'super_admin'
 ON CONFLICT DO NOTHING;
 --> statement-breakpoint
 SELECT setval('menus_id_seq', GREATEST((SELECT MAX("id") FROM "menus"), 1));


### PR DESCRIPTION
## 问题

在全新数据库上按文档顺序执行 `npm run db:migrate`（先迁移，后 `db:seed`）时报错：

```
insert or update on table "dict_items" violates foreign key constraint "dict_items_dict_id_dicts_id_fk"
Key (dict_id)=(7) is not present in table "dicts".
```

Closes #5

## 根因

文档里的执行顺序（`db:migrate` → `db:seed`）是正确且标准的，**不是**问题所在。问题是两个**数据迁移**违反了「迁移必须能在空库上独立运行」的约定，错误地依赖了尚未填充的种子数据：

- **`0084_scheduled_announcement.sql`** — 向 `dict_items` 插入硬编码 `dict_id = 7`，全新库里 `dicts` 表为空 → 外键报错（migrate 当前就死在这里）。
- **`0177_romantic_leech.sql`** — 向 `role_menus` 插入硬编码 `role_id = 1`，全新库里 `roles` 表为空 → 紧接着也会失败。
- `0178` / `0180` 已经使用了安全写法（按 `roles.code = 'super_admin'` join），`menus.parent_id` 无外键，故菜单插入安全。

这些数据在 seed 文件里都存在，所以 `db:seed` 仍会完整填充新库。

## 改动（仅 2 个迁移文件，不动 schema）

- **0084**：`dict_items` 的 `INSERT … VALUES` 改为 `INSERT … SELECT … WHERE EXISTS (SELECT 1 FROM "dicts" WHERE "id" = 7)`——空库自动跳过，已 seed 的库仍会补数据；`cron_jobs` 那条不动。
- **0177**：`role_menus` 改为按 `roles.code = 'super_admin'` join（对齐 0178/0180 的防御式写法）——空库自动跳过。
- 两者均保留 `ON CONFLICT DO NOTHING` 以保证幂等。

> 编辑历史迁移体是安全的：drizzle 按 journal 时间戳决定是否执行，不按文件内容，已迁移的库不会重跑或报错。

## 验证（Postgres 18，与 issue 环境一致）

在全新库上完整跑通：

- ✅ `db:migrate` 完成（仅剩无害的标识符截断 NOTICE）
- ✅ `db:seed` 完成，无外键报错
- ✅ 数据核对：`dict_id = 7` 含「定时发布」；调度中心菜单 535–539 均正确绑定到 `super_admin`
- ✅ 重复执行 `db:migrate` 幂等无报错
- 无需 `db:generate`（未改 schema）

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>